### PR TITLE
Add camera access permission

### DIFF
--- a/Book Logger/Info.plist
+++ b/Book Logger/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Scan pages of your books using Book Logger</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Catalogue book pages</string>
 	<key>CFBundleDevelopmentRegion</key>


### PR DESCRIPTION
Adding this will fix crashing on devices. I first tried to add a page while testing the app on my iPhone X. It'll then crash because it'll attempt to access the camera but we haven't listed camera access in our `info.plist`.