### PR TITLE
Add an image picker action sheet for camera + library access

### DIFF
--- a/Book Logger/PageController.swift
+++ b/Book Logger/PageController.swift
@@ -2,68 +2,90 @@ import UIKit
 import TesseractOCR
 
 class PageController: UIViewController {
+  
+  @IBOutlet weak var transcriptView: UITextView!
+  @IBOutlet weak var pageImageView: UIImageView!
+  var page: PageData! = nil
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
     
-    @IBOutlet weak var transcriptView: UITextView!
-    @IBOutlet weak var pageImageView: UIImageView!
-    var page: PageData! = nil
+    pageImageView.image = page.img
+    transcriptView.text = page.txt
+    
+    DispatchQueue.global(qos: .background).async {
+      let OCRText = self.generateTranscript()
+      
+      DispatchQueue.main.async {
+        self.updateTranscriptView(OCRText: OCRText)
+      }
+    }
+  }
+  
+  @IBAction func backToPages(_ sender: Any) {
+    dismiss(animated: true, completion: nil)
+  }
+  
+  func generateTranscript() -> String {
+    // Scale image for OCR
+    let scaledImage = page.img.scaleImage(640)!
+    // Perform OCR and retrieve the recognized text
+    let OCRText = self.performImageRecognition(scaledImage)
+    // Save to file
+    let txtData = OCRText
+    let txtName = "page.txt"
+    let txtURL = page.dir.appendingPathComponent(txtName)
+    // overwrite data to page directory
+    do {
+      try FileManager.default.removeItem(atPath: txtURL.absoluteString)
+      try txtData.write(to: txtURL, atomically: false, encoding: .utf8)
+    } catch {
+      print("error saving file:", error)
+    }
+    return OCRText
+  }
+  
+  func updateTranscriptView(OCRText: String) {
+    // update view
+    page.txt = OCRText
+    transcriptView.text = page.txt
+  }
+  
+  // Tesseract Image Recognition
+  func performImageRecognition(_ image: UIImage) -> String {
+    if let tesseract = G8Tesseract(language: "eng") {
+      tesseract.engineMode = .tesseractCubeCombined // Run Tesseract and Cube for best accuracy
+      tesseract.pageSegmentationMode = .auto // Have Tesseract automatically recognize paragraph breaks
+      tesseract.image = image.g8_blackAndWhite() // Preprocessing step
+      tesseract.recognize() // run image recognition
+      return tesseract.recognizedText
+    }
+    else {
+      let errorMessage = "Could not initiate image recognition."
+      return errorMessage
+    }
+  }
+  
+}
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        pageImageView.image = page.img
-        transcriptView.text = page.txt
-        
-        DispatchQueue.global(qos: .background).async {
-            let OCRText = self.generateTranscript()
-            
-            DispatchQueue.main.async {
-                self.updateTranscriptView(OCRText: OCRText)
-            }
-        }
+// MARK: - UIImage extension
+extension UIImage {
+  func scaleImage(_ maxDimension: CGFloat) -> UIImage? {
+    var scaledSize = CGSize(width: maxDimension, height: maxDimension)
+    
+    if size.width > size.height {
+      let scaleFactor = size.height / size.width
+      scaledSize.height = scaledSize.width * scaleFactor
+    }
+    else {
+      let scaleFactor = size.width / size.height
+      scaledSize.width = scaledSize.height * scaleFactor
     }
     
-    @IBAction func backToPages(_ sender: Any) {
-        dismiss(animated: true, completion: nil)
-    }
-    
-    func generateTranscript() -> String {
-        // Scale image for OCR
-        let scaledImage = page.img.scaleImage(640)!
-        // Perform OCR and retrieve the recognized text
-        let OCRText = self.performImageRecognition(scaledImage)
-        // Save to file
-        let txtData = OCRText
-        let txtName = "page.txt"
-        let txtURL = page.dir.appendingPathComponent(txtName)
-        // overwrite data to page directory
-        do {
-            try FileManager.default.removeItem(atPath: txtURL.absoluteString)
-            try txtData.write(to: txtURL, atomically: false, encoding: .utf8)
-        } catch {
-            print("error saving file:", error)
-        }
-        return OCRText
-    }
-    
-    func updateTranscriptView(OCRText: String) {
-        // update view
-        page.txt = OCRText
-        transcriptView.text = page.txt
-    }
-    
-    // Tesseract Image Recognition
-    func performImageRecognition(_ image: UIImage) -> String {
-        if let tesseract = G8Tesseract(language: "eng") {
-            tesseract.engineMode = .tesseractCubeCombined // Run Tesseract and Cube for best accuracy
-            tesseract.pageSegmentationMode = .auto // Have Tesseract automatically recognize paragraph breaks
-            tesseract.image = image.g8_blackAndWhite() // Preprocessing step
-            tesseract.recognize() // run image recognition
-            return tesseract.recognizedText
-        }
-        else {
-          let errorMessage = "Could not initiate image recognition."
-          return errorMessage
-        }
-    }
-    
+    UIGraphicsBeginImageContext(scaledSize)
+    draw(in: CGRect(origin: .zero, size: scaledSize))
+    let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
+    return scaledImage
+  }
 }

--- a/Book Logger/PagesController.swift
+++ b/Book Logger/PagesController.swift
@@ -1,175 +1,172 @@
 import UIKit
 
 class PagesController: CollectionViewController, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+  
+  @IBOutlet weak var collectionView: UICollectionView!
+  var currentImage = UIImage(named: "no-image")
+  let imagePicker = UIImagePickerController()
+  
+  var book: BookData! = nil
+  
+  override func viewDidLoad() {
+    imagePicker.delegate = self
+  }
+  
+  override func viewWillAppear(_ animated: Bool) {
+    collectionView.reloadData()
+  }
+  
+  override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return book.pages.count + 1
+  }
+  
+  override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     
-    @IBOutlet weak var collectionView: UICollectionView!
-    var currentImage = UIImage(named: "no-image")
-    let imagePicker = UIImagePickerController()
+    let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "pageCell", for: indexPath) as! PageCell
     
-    var book: BookData! = nil
+    cell.imageView.layer.borderWidth = 1
+    cell.imageView.layer.borderColor = UIColor.lightGray.cgColor
     
-    override func viewDidLoad() {
-        imagePicker.delegate = self
+    // Index 0 is used for 'new page'
+    if indexPath.row > 0 {
+      // No '+' on the button
+      cell.plusLabel.text = ""
+      
+      // load image from current pages
+      cell.imageView.image = book.pages[indexPath.row-1].img
+    } else {
+      // This cell is for 'new page'
+      cell.plusLabel.text = "+"
+      cell.imageView.image = nil
     }
     
-    override func viewWillAppear(_ animated: Bool) {
-        collectionView.reloadData()
+    return cell
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    // Index 0 is used for 'new page'
+    if indexPath.row > 0 {
+      // go to existing page
+      let page = book.pages[indexPath.row-1]
+      sequeToPage(page: page)
+    } else {
+      // get image, create new page, then segue there
+      presentImagePicker()
+    }
+  }
+  
+  func sequeToPage(page: PageData) {
+    performSegue(withIdentifier: "toPage", sender: page)
+  }
+  
+  override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+    if segue.identifier == "toPage" {
+      // If we are headed to a new page,
+      // create that page with the proper image (and transcript)
+      let destination = segue.destination as! PageController
+      let page = sender as! PageData
+      destination.page = page
+    }
+  }
+  
+  @IBAction func presentImagePicker() {
+    let imagePickerActionSheet = UIAlertController(title: "Capture/Upload Page",
+                                                   message: nil, preferredStyle: .actionSheet)
+    if UIImagePickerController.isSourceTypeAvailable(.camera) {
+      let cameraButton = UIAlertAction(title: "Take Photo",
+                                       style: .default) { (alert) -> Void in
+                                        self.imagePicker.delegate = self
+                                        self.imagePicker.sourceType = .camera
+                                        self.imagePicker.allowsEditing = true
+                                        self.present(self.imagePicker, animated: true, completion: nil)
+      }
+      imagePickerActionSheet.addAction(cameraButton)
+    }
+    else{
+      print("Do not have access to camera, trying photo library")
     }
     
-    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return book.pages.count + 1
+    if UIImagePickerController.isSourceTypeAvailable(.photoLibrary){
+      let libraryButton = UIAlertAction(title: "Choose Existing",
+                                        style: .default) { (alert) -> Void in
+                                          self.imagePicker.delegate = self
+                                          self.imagePicker.sourceType = .photoLibrary
+                                          self.imagePicker.allowsEditing = false // Disallow editing when choosing existing images to speed up the UX.
+                                          self.present(self.imagePicker, animated: true, completion: nil)
+      }
+      imagePickerActionSheet.addAction(libraryButton)
+    }
+    else {
+      print("Do not have access to photo library")
     }
     
-    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "pageCell", for: indexPath) as! PageCell
-        
-        cell.imageView.layer.borderWidth = 1
-        cell.imageView.layer.borderColor = UIColor.lightGray.cgColor
-        
-        // Index 0 is used for 'new page'
-        if indexPath.row > 0 {
-            // No '+' on the button
-            cell.plusLabel.text = ""
-            
-            // load image from current pages
-            cell.imageView.image = book.pages[indexPath.row-1].img
-        } else {
-            // This cell is for 'new page'
-            cell.plusLabel.text = "+"
-            cell.imageView.image = nil
-        }
-        
-        return cell
+    
+    let cancelButton = UIAlertAction(title: "Cancel", style: .cancel)
+    imagePickerActionSheet.addAction(cancelButton)
+    
+    present(imagePickerActionSheet, animated: true)
+  }
+  
+  func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
+    /*
+     Get the image from the info dictionary.
+     If the user edited the image (from the camera), use their edited image. Else use the original (from the library).
+     */
+    if let editedImage = info[UIImagePickerControllerEditedImage] as? UIImage{
+      currentImage = editedImage
+    }
+    else if let selectedImage = info[UIImagePickerControllerOriginalImage] as? UIImage{
+      currentImage = selectedImage
     }
     
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        // Index 0 is used for 'new page'
-        if indexPath.row > 0 {
-            // go to existing page
-            let page = book.pages[indexPath.row-1]
-            sequeToPage(page: page)
-        } else {
-            // get image, create new page, then segue there
-            openCameraButton()
-        }
+    // Dismiss the UIImagePicker after selection
+    self.dismiss(animated: true) {
+      // Segue to new page after image capture
+      let page = self.saveImage(image: self.currentImage!)
+      self.performSegue(withIdentifier: "toPage", sender: page)
+    }
+  }
+  
+  func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+    self.dismiss(animated: true)
+  }
+  
+  func saveImage(image: UIImage, imageText: String = "Reading page...") -> PageData {
+    // create new directiory for image / transcript
+    
+    // The directory is "page" + unix time stamp
+    let unixTime = NSDate().timeIntervalSince1970
+    let pageDir = book.dir.appendingPathComponent("page\(unixTime)")
+    do {
+      try FileManager.default.createDirectory(atPath: (pageDir.path), withIntermediateDirectories: true, attributes: nil)
+    }
+    catch let error as NSError {
+      NSLog("Unable to create page directory \(error.debugDescription)")
     }
     
-    func sequeToPage(page: PageData) {
-        performSegue(withIdentifier: "toPage", sender: page)
+    // new image file
+    let imgData = UIImagePNGRepresentation(image)
+    let imgName = "page.png"
+    let imgURL = pageDir.appendingPathComponent(imgName)
+    // new txt file
+    let txtData = imageText
+    let txtName = "page.txt"
+    let txtURL = pageDir.appendingPathComponent(txtName)
+    // write data to page directory
+    do {
+      try imgData?.write(to: imgURL)
+      try txtData.write(to: txtURL, atomically: false, encoding: .utf8)
+    } catch {
+      print("error saving file:", error)
     }
     
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "toPage" {
-            // If we are headed to a new page,
-            // create that page with the proper image (and transcript)
-            let destination = segue.destination as! PageController
-            let page = sender as! PageData
-            destination.page = page
-        }
-    }
-    
-    @IBAction func openCameraButton() {
-        if UIImagePickerController.isSourceTypeAvailable(.camera) {
-            imagePicker.sourceType = .camera;
-            imagePicker.allowsEditing = false
-            self.present(imagePicker, animated: true, completion: nil)
-        } else {
-            print("Do not have access to camera, trying photo library")
-            openPhotoLibraryButton()
-        }
-    }
-    
-    @IBAction func openPhotoLibraryButton() {
-        if UIImagePickerController.isSourceTypeAvailable(.photoLibrary) {
-            imagePicker.sourceType = .photoLibrary;
-            imagePicker.allowsEditing = true
-            self.present(imagePicker, animated: true, completion: nil)
-        } else {
-            print("Do not have access to photo library")
-        }
-    }
-    
-    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
-        /*
-         Get the image from the info dictionary.
-         If no need to edit the photo, use `UIImagePickerControllerOriginalImage`
-         instead of `UIImagePickerControllerEditedImage`
-         */
-        if let editedImage = info[UIImagePickerControllerEditedImage] as? UIImage{
-            currentImage = editedImage
-        }
-        
-        // Dismiss the UIImagePicker after selection
-        self.dismiss(animated: true) {
-            // Segue to new page after image capture
-            let page = self.saveImage(image: self.currentImage!)
-            self.performSegue(withIdentifier: "toPage", sender: page)
-        }
-    }
-    
-    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
-        self.dismiss(animated: true)
-    }
-    
-    func saveImage(image: UIImage, imageText: String = "Reading page...") -> PageData {
-        // create new directiory for image / transcript
-        
-        // The directory is "page" + unix time stamp
-        let unixTime = NSDate().timeIntervalSince1970
-        let pageDir = book.dir.appendingPathComponent("page\(unixTime)")
-        do {
-            try FileManager.default.createDirectory(atPath: (pageDir.path), withIntermediateDirectories: true, attributes: nil)
-        }
-        catch let error as NSError {
-            NSLog("Unable to create page directory \(error.debugDescription)")
-        }
-        
-        // new image file
-        let imgData = UIImagePNGRepresentation(image)
-        let imgName = "page.png"
-        let imgURL = pageDir.appendingPathComponent(imgName)
-        // new txt file
-        let txtData = imageText
-        let txtName = "page.txt"
-        let txtURL = pageDir.appendingPathComponent(txtName)
-        // write data to page directory
-        do {
-            try imgData?.write(to: imgURL)
-            try txtData.write(to: txtURL, atomically: false, encoding: .utf8)
-        } catch {
-            print("error saving file:", error)
-        }
-        
-        // create page to pass along to new PageViewController
-        let page = PageData(dir: pageDir, img: image, txt: txtData)
-        book.pages.append(page)
-        return page
-    }    
-    
-    @IBAction func backToBooks(_ sender: Any) {
-        dismiss(animated: true, completion: nil)
-    }
-}
-
-// MARK: - UIImage extension
-extension UIImage {
-    func scaleImage(_ maxDimension: CGFloat) -> UIImage? {
-        var scaledSize = CGSize(width: maxDimension, height: maxDimension)
-        
-        if size.width > size.height {
-            let scaleFactor = size.height / size.width
-            scaledSize.height = scaledSize.width * scaleFactor
-        }
-        else {
-            let scaleFactor = size.width / size.height
-            scaledSize.width = scaledSize.height * scaleFactor
-        }
-        
-        UIGraphicsBeginImageContext(scaledSize)
-        draw(in: CGRect(origin: .zero, size: scaledSize))
-        let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return scaledImage
-    }
+    // create page to pass along to new PageViewController
+    let page = PageData(dir: pageDir, img: image, txt: txtData)
+    book.pages.append(page)
+    return page
+  }
+  
+  @IBAction func backToBooks(_ sender: Any) {
+    dismiss(animated: true, completion: nil)
+  }
 }


### PR DESCRIPTION
This adds an imagePicker action sheet that presents options to both take a picture with the camera and pick an image from the library when adding a page. Before, the app would make the user use the camera if it had access and only allow library access when it wasn't available.